### PR TITLE
Fix bug: Remove incorrect quotation Marks in Java Command Paths

### DIFF
--- a/src/simod/control_flow/discovery.py
+++ b/src/simod/control_flow/discovery.py
@@ -143,8 +143,8 @@ def add_bpmn_diagram_to_model(bpmn_model_path: Path):
     args = [
         "java",
         "-jar",
-        '"' + str(bpmn_layout_jar_path) + '"',
-        '"' + str(bpmn_model_path) + '"'
+        str(bpmn_layout_jar_path),
+        str(bpmn_model_path)
     ]
     print_step(f"Adding BPMN diagram to the model: {args}")
     execute_external_command(args)


### PR DESCRIPTION
When running Simod in a Docker container with complete_configuration.yml, the Java command for BPMN layout generation fails due to quotation marks (") around file paths. The error occurs when executing the bpmn-layout-1.0.6-jar-with-dependencies.jar command, resulting in:

Adding BPMN diagram to the model: ['java', '-jar', '"/usr/src/Simod/src/simod/control_flow/lib/bpmn-layout-1.0.6-jar-with-dependencies.jar"', '"/usr/src/Simod/outputs/20250428_211724_A07E83B1_0E85_45DD_B8C1_422790F8FEB1/best_result/LoanApp_simplified_train.bpmn"']
Error: Unable to access jarfile "/usr/src/Simod/src/simod/control_flow/lib/bpmn-layout-1.0.6-jar-with-dependencies.jar"

This happens because the quotation marks are incorrectly included in the command, causing the Java runtime to misinterpret the JAR file path. When removing the quotation mark around the paths, the command runs successfully if the modified source code is mounted.

To reproduce this bug just follow the Docker guide in the readme file in the repo and run with complete_configuration.yml (havent tried with the others). And the error message should be displayed at the end.
